### PR TITLE
Add a loop utils class to gather some loop transformation support.

### DIFF
--- a/source/opt/CMakeLists.txt
+++ b/source/opt/CMakeLists.txt
@@ -51,6 +51,7 @@ add_library(SPIRV-Tools-opt
   local_ssa_elim_pass.h
   log.h
   loop_descriptor.h
+  loop_utils.h
   mem_pass.h
   merge_return_pass.h
   module.h
@@ -113,6 +114,7 @@ add_library(SPIRV-Tools-opt
   local_single_store_elim_pass.cpp
   local_ssa_elim_pass.cpp
   loop_descriptor.cpp
+  loop_utils.cpp
   mem_pass.cpp
   merge_return_pass.cpp
   module.cpp

--- a/source/opt/basic_block.h
+++ b/source/opt/basic_block.h
@@ -133,6 +133,8 @@ class BasicBlock {
   void ForEachSuccessorLabel(
       const std::function<void(const uint32_t)>& f) const;
 
+  void ForEachSuccessorLabel(const std::function<void(uint32_t*)>& f);
+
   // Returns true if |block| is a direct successor of |this|.
   bool IsSuccessor(const ir::BasicBlock* block) const;
 

--- a/source/opt/cfg.h
+++ b/source/opt/cfg.h
@@ -68,6 +68,34 @@ class CFG {
   void ComputeStructuredOrder(ir::Function* func, ir::BasicBlock* root,
                               std::list<ir::BasicBlock*>* order);
 
+  // Registers |blk| as a basic block in the cfg, this also updates the
+  // predecessor lists of each successor of |blk|.
+  void RegisterBlock(ir::BasicBlock* blk) {
+    uint32_t blk_id = blk->id();
+    id2block_[blk_id] = blk;
+    AddEdges(blk);
+  }
+
+  // Registers |blk| to all of its successors.
+  void AddEdges(ir::BasicBlock* blk) {
+    uint32_t blk_id = blk->id();
+    // Force the creation of an entry, not all basic block have predecessors
+    // (such as the entry blocks and some unreachables).
+    label2preds_[blk_id];
+    blk->ForEachSuccessorLabel(
+        [blk_id, this](uint32_t succ_id) { AddEdge(blk_id, succ_id); });
+  }
+
+  // Registers the basic block id |pred_blk_id| as being a predecessor of the
+  // basic block id |succ_blk_id|.
+  void AddEdge(uint32_t pred_blk_id, uint32_t succ_blk_id) {
+    label2preds_[succ_blk_id].push_back(pred_blk_id);
+  }
+
+  // Removes any edges that no longer exist from the predecessor mapping for
+  // the basic block id |blk_id|.
+  void RemoveNonExistingEdges(uint32_t blk_id);
+
  private:
   using cbb_ptr = const ir::BasicBlock*;
 

--- a/source/opt/def_use_manager.cpp
+++ b/source/opt/def_use_manager.cpp
@@ -100,8 +100,10 @@ bool DefUseManager::WhileEachUser(
     const ir::Instruction* def,
     const std::function<bool(ir::Instruction*)>& f) const {
   // Ensure that |def| has been registered.
-  assert(def && def == GetDef(def->result_id()) &&
+  assert(def && (!def->HasResultId() || def == GetDef(def->result_id())) &&
          "Definition is not registered.");
+  if (!def->HasResultId()) return true;
+
   auto end = id_to_users_.end();
   for (auto iter = UsersBegin(def); UsersNotEnd(iter, end, def); ++iter) {
     if (!f(iter->second)) return false;
@@ -132,8 +134,10 @@ bool DefUseManager::WhileEachUse(
     const ir::Instruction* def,
     const std::function<bool(ir::Instruction*, uint32_t)>& f) const {
   // Ensure that |def| has been registered.
-  assert(def && def == GetDef(def->result_id()) &&
+  assert(def && (!def->HasResultId() || def == GetDef(def->result_id())) &&
          "Definition is not registered.");
+  if (!def->HasResultId()) return true;
+
   auto end = id_to_users_.end();
   for (auto iter = UsersBegin(def); UsersNotEnd(iter, end, def); ++iter) {
     ir::Instruction* user = iter->second;

--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -197,10 +197,15 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
   uint32_t GetSingleWordOperand(uint32_t index) const;
   // Sets the |index|-th in-operand's data to the given |data|.
   inline void SetInOperand(uint32_t index, std::vector<uint32_t>&& data);
+  // Sets the |index|-th operand's data to the given |data|.
+  // This is for in-operands modification only, but with |index| expressed in
+  // terms of operand index rather than in-operand index.
+  inline void SetOperand(uint32_t index, std::vector<uint32_t>&& data);
   // Sets the result type id.
   inline void SetResultType(uint32_t ty_id);
   // Sets the result id
   inline void SetResultId(uint32_t res_id);
+  inline bool HasResultId() const { return result_id_ != 0; }
   // Remove the |index|-th operand
   void RemoveOperand(uint32_t index) {
     operands_.erase(operands_.begin() + index);
@@ -450,9 +455,14 @@ inline void Instruction::AddOperand(Operand&& operand) {
 
 inline void Instruction::SetInOperand(uint32_t index,
                                       std::vector<uint32_t>&& data) {
-  assert(index + TypeResultIdCount() < operands_.size() &&
-         "operand index out of bound");
-  operands_[index + TypeResultIdCount()].words = std::move(data);
+  SetOperand(index + TypeResultIdCount(), std::move(data));
+}
+
+inline void Instruction::SetOperand(uint32_t index,
+                                    std::vector<uint32_t>&& data) {
+  assert(index < operands_.size() && "operand index out of bound");
+  assert(index >= TypeResultIdCount() && "operand is not a in-operand");
+  operands_[index].words = std::move(data);
 }
 
 inline void Instruction::SetResultId(uint32_t res_id) {

--- a/source/opt/loop_descriptor.h
+++ b/source/opt/loop_descriptor.h
@@ -68,14 +68,59 @@ class Loop {
   // OpLoopMerge instruction.
   inline BasicBlock* GetHeaderBlock() { return loop_header_; }
   inline const BasicBlock* GetHeaderBlock() const { return loop_header_; }
+  inline void SetHeaderBlock(BasicBlock* header) { loop_header_ = header; }
+
+  // Returns true if the loop can be considered as structured according to
+  // SPIR-V rules:
+  //  - Has a merge block;
+  //  - Has a continue block.
+  inline bool IsStructuredCompliant() const {
+    return GetLatchBlock() && GetMergeBlock();
+  }
+
+  // Returns true if the loop is structured according to SPIR-V rules:
+  //  - Has a merge block;
+  //  - Has a continue block;
+  //  - Has an OpLoopMerge instruction.
+  inline bool IsStructured() const {
+    return IsStructuredCompliant() && GetHeaderBlock()->GetLoopMergeInst();
+  }
+
+  // Updates the OpLoopMerge instruction to reflect the current state of the
+  // loop.
+  inline void UpdateLoopMergeInst() {
+    assert(IsStructured() && "The loop is not structured");
+    ir::Instruction* merge_inst = GetHeaderBlock()->GetLoopMergeInst();
+    merge_inst->SetInOperand(0, {GetMergeBlock()->id()});
+    merge_inst->SetInOperand(1, {GetLatchBlock()->id()});
+  }
 
   // Returns the latch basic block (basic block that holds the back-edge).
+  // These functions return nullptr if the loop is not structured (i.e. if it
+  // has more than one backedge).
   inline BasicBlock* GetLatchBlock() { return loop_continue_; }
   inline const BasicBlock* GetLatchBlock() const { return loop_continue_; }
+  // Sets |latch| as the loop unique continue block. A continue block must have
+  // the following properties:
+  //  - |latch| must be in the loop;
+  //  - must be the only block branching back to the header block.
+  // If the loop has an OpLoopMerge in its header, this instruction is also
+  // updated.
+  void SetLatchBlock(BasicBlock* latch);
 
-  // Returns the BasicBlock which marks the end of the loop.
+  inline bool HasUniqueMergeBlock() { return !!loop_merge_; }
+  // Returns the basic block which marks the end of the loop.
+  // These functions return nullptr if the loop is not structured.
   inline BasicBlock* GetMergeBlock() { return loop_merge_; }
   inline const BasicBlock* GetMergeBlock() const { return loop_merge_; }
+  // Sets |merge| as the loop merge block. A merge block must have the following
+  // properties:
+  //  - |merge| must not be in the loop;
+  //  - all its predecessors must be in the loop.
+  //  - it must not be already used as merge block.
+  // If the loop has an OpLoopMerge in its header, this instruction is also
+  // updated.
+  void SetMergeBlock(BasicBlock* merge);
 
   // Returns the loop pre-header, nullptr means that the loop predecessor does
   // not qualify as a preheader.
@@ -87,8 +132,22 @@ class Loop {
   // Returns the loop pre-header.
   inline const BasicBlock* GetPreHeaderBlock() const { return loop_preheader_; }
 
+  // Returns the loop pre-header, if there is no suitable preheader it will be
+  // created.
+  BasicBlock* GetOrCreatePreHeaderBlock(ir::IRContext* context);
+
   // Returns true if this loop contains any nested loops.
   inline bool HasNestedLoops() const { return nested_loops_.size() != 0; }
+
+  // Fills |exit_blocks| with all basic blocks that are not in the loop and has
+  // at least one predecessor in the loop.
+  void GetExitBlocks(IRContext* context,
+                     std::unordered_set<uint32_t>* exit_blocks) const;
+
+  // Returns true if the loop is in a Loop Closed SSA form.
+  // In LCSSA form, all in-loop definitions are used in the loop or in phi
+  // instructions in the loop exit blocks.
+  bool IsLCSSA() const;
 
   // Returns the depth of this loop in the loop nest.
   // The outer-most loop has a depth of 1.
@@ -139,10 +198,19 @@ class Loop {
     assert(IsBasicBlockInLoopSlow(bb) &&
            "Basic block does not belong to the loop");
 
+    AddBasicBlock(bb);
+  }
+
+  // Adds the Basic Block |bb| this loop and its parents.
+  void AddBasicBlock(const BasicBlock* bb) {
     for (Loop* loop = this; loop != nullptr; loop = loop->parent_) {
       loop_basic_blocks_.insert(bb->id());
     }
   }
+
+  // Sets the parent loop of this loop, that is, a loop which contains this loop
+  // as a nested child loop.
+  inline void SetParent(Loop* parent) { parent_ = parent; }
 
  private:
   // The block which marks the start of the loop.
@@ -167,22 +235,25 @@ class Loop {
   // computed only when needed on demand.
   BasicBlockListTy loop_basic_blocks_;
 
-  // Check that |bb| is inside the loop using domination properties.
+  // Check that |bb| is inside the loop using domination property.
   // Note: this is for assertion purposes only, IsInsideLoop should be used
   // instead.
   bool IsBasicBlockInLoopSlow(const BasicBlock* bb);
-
-  // Sets the parent loop of this loop, that is, a loop which contains this loop
-  // as a nested child loop.
-  inline void SetParent(Loop* parent) { parent_ = parent; }
 
   // Returns the loop preheader if it exists, returns nullptr otherwise.
   BasicBlock* FindLoopPreheader(IRContext* context,
                                 opt::DominatorAnalysis* dom_analysis);
 
+  // Sets |latch| as the loop unique continue block. No checks are performed
+  // here.
+  inline void SetLatchBlockImpl(BasicBlock* latch) { loop_continue_ = latch; }
+  // Sets |merge| as the loop merge block. No checks are performed here.
+  inline void SetMergeBlockImpl(BasicBlock* merge) { loop_merge_ = merge; }
+
   // This is only to allow LoopDescriptor::dummy_top_loop_ to add top level
   // loops as child.
   friend class LoopDescriptor;
+  friend class LoopUtils;
 };
 
 // Loop descriptions class for a given function.
@@ -229,6 +300,11 @@ class LoopDescriptor {
   }
   inline const_iterator cend() const {
     return const_iterator::end(&dummy_top_loop_);
+  }
+
+  // Returns the inner most loop that contains the basic block |bb|.
+  inline void SetBasicBlockToLoop(uint32_t bb_id, Loop* loop) {
+    basic_block_to_loop_[bb_id] = loop;
   }
 
  private:

--- a/source/opt/loop_utils.cpp
+++ b/source/opt/loop_utils.cpp
@@ -1,0 +1,379 @@
+// Copyright (c) 2018 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <memory>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "opt/cfg.h"
+#include "opt/ir_builder.h"
+#include "opt/ir_context.h"
+#include "opt/loop_descriptor.h"
+#include "opt/loop_utils.h"
+
+namespace spvtools {
+namespace opt {
+
+namespace {
+// Return true if |bb| is dominated by at least one block in |exits|
+static inline bool DominatesAnExit(
+    ir::BasicBlock* bb, const std::unordered_set<ir::BasicBlock*>& exits,
+    const opt::DominatorTree& dom_tree) {
+  for (ir::BasicBlock* e_bb : exits)
+    if (dom_tree.Dominates(bb, e_bb)) return true;
+  return false;
+}
+
+// Utility class to rewrite out-of-loop uses of an in-loop definition in terms
+// of phi instructions to achieve a LCSSA form.
+// For a given definition, the class user registers phi instructions using that
+// definition in all loop exit blocks by which the definition escapes.
+// Then, when rewriting a use of the definition, the rewriter walks the
+// paths from the use the loop exits. At each step, it will insert a phi
+// instruction to merge the incoming value according to exit blocks definition.
+class LCSSARewriter {
+ public:
+  LCSSARewriter(ir::IRContext* context, const opt::DominatorTree& dom_tree,
+                const std::unordered_set<ir::BasicBlock*>& exit_bb,
+                const ir::Instruction& def_insn)
+      : context_(context),
+        cfg_(context_->cfg()),
+        dom_tree_(dom_tree),
+        insn_type_(def_insn.type_id()),
+        exit_bb_(exit_bb) {}
+
+  // Rewrites the use of |def_insn_| by the instruction |user| at the index
+  // |operand_index| in terms of phi instruction. This recursively builds new
+  // phi instructions from |user| to the loop exit blocks' phis. The use of
+  // |def_insn_| in |user| is replaced by the relevant phi instruction at the
+  // end of the operation.
+  // It is assumed that |user| does not dominates any of the loop exit basic
+  // block. This operation does not update the def/use manager, instead it
+  // records what needs to be updated. The actual update is performed by
+  // UpdateManagers.
+  void RewriteUse(ir::BasicBlock* bb, ir::Instruction* user,
+                  uint32_t operand_index) {
+    assert((user->opcode() != SpvOpPhi || bb != GetParent(user)) &&
+           "The root basic block must be the incoming edge if |user| is a phi "
+           "instruction");
+    assert(
+        (user->opcode() == SpvOpPhi || bb == GetParent(user)) &&
+        "The root basic block must be the instruction parent if |user| is not "
+        "phi instruction");
+
+    const ir::Instruction& new_def = GetOrBuildIncoming(bb->id());
+
+    user->SetOperand(operand_index, {new_def.result_id()});
+    rewritten.insert(user);
+  }
+
+  // Notifies the addition of a phi node built to close the loop.
+  inline void RegisterExitPhi(ir::BasicBlock* bb, ir::Instruction* phi) {
+    bb_to_phi[bb->id()] = phi;
+    rewritten.insert(phi);
+  }
+
+  // In-place update of some managers (avoid full invalidation).
+  inline void UpdateManagers() {
+    opt::analysis::DefUseManager* def_use_mgr = context_->get_def_use_mgr();
+    // Register all new definitions.
+    for (ir::Instruction* insn : rewritten) {
+      def_use_mgr->AnalyzeInstDef(insn);
+    }
+    // Register all new uses.
+    for (ir::Instruction* insn : rewritten) {
+      def_use_mgr->AnalyzeInstUse(insn);
+    }
+  }
+
+ private:
+  // Return the basic block that |instr| belongs to.
+  ir::BasicBlock* GetParent(ir::Instruction* instr) {
+    return context_->get_instr_block(instr);
+  }
+
+  // Return the new def to use for the basic block |bb_id|.
+  // If |bb_id| does not have a suitable def to use then we:
+  //   - return the common def used by all predecessors;
+  //   - if there is no common def, then we build a new phi instr at the
+  //     beginning of |bb_id| and return this new instruction.
+  const ir::Instruction& GetOrBuildIncoming(uint32_t bb_id) {
+    assert(cfg_->block(bb_id) != nullptr && "Unknown basic block");
+
+    ir::Instruction*& incoming_phi = bb_to_phi[bb_id];
+    if (incoming_phi) {
+      return *incoming_phi;
+    }
+
+    // Check if one of the loop exit basic block dominates |bb_id|.
+    for (const ir::BasicBlock* e_bb : exit_bb_) {
+      if (dom_tree_.Dominates(e_bb->id(), bb_id)) {
+        incoming_phi = bb_to_phi[e_bb->id()];
+        assert(incoming_phi && "No closing phi node ?");
+        return *incoming_phi;
+      }
+    }
+
+    // Process parents, they will returns their suitable phi.
+    // If they are all the same, this means this basic block is dominated by a
+    // common block, so we won't need to build a phi instruction.
+    std::vector<uint32_t> incomings;
+    for (uint32_t pred_id : cfg_->preds(bb_id)) {
+      incomings.push_back(GetOrBuildIncoming(pred_id).result_id());
+      incomings.push_back(pred_id);
+    }
+    uint32_t first_id = incomings.front();
+    size_t idx = 0;
+    for (; idx < incomings.size(); idx += 2)
+      if (first_id != incomings[idx]) break;
+
+    if (idx >= incomings.size()) {
+      incoming_phi = bb_to_phi[incomings[1]];
+      return *incoming_phi;
+    }
+
+    // We have at least 2 definitions to merge, so we need a phi instruction.
+    ir::BasicBlock* block = cfg_->block(bb_id);
+
+    opt::InstructionBuilder<> builder(context_, &*block->begin());
+    incoming_phi = builder.AddPhi(insn_type_, incomings);
+
+    rewritten.insert(incoming_phi);
+
+    return *incoming_phi;
+  }
+
+  ir::IRContext* context_;
+  ir::CFG* cfg_;
+  const opt::DominatorTree& dom_tree_;
+  uint32_t insn_type_;
+  std::unordered_map<uint32_t, ir::Instruction*> bb_to_phi;
+  std::unordered_set<ir::Instruction*> rewritten;
+  const std::unordered_set<ir::BasicBlock*>& exit_bb_;
+};
+}  // namespace
+
+void LoopUtils::CreateLoopDedicateExits() {
+  ir::Function* function = loop_->GetHeaderBlock()->GetParent();
+  ir::LoopDescriptor& loop_desc = *context_->GetLoopDescriptor(function);
+  ir::CFG& cfg = *context_->cfg();
+  opt::analysis::DefUseManager* def_use_mgr = context_->get_def_use_mgr();
+
+  constexpr ir::IRContext::Analysis PreservedAnalyses =
+      ir::IRContext::kAnalysisDefUse |
+      ir::IRContext::kAnalysisInstrToBlockMapping;
+
+  // Gathers the set of basic block that are not in this loop and have at least
+  // one predecessor in the loop and one not in the loop.
+  std::unordered_set<uint32_t> exit_bb_set;
+  loop_->GetExitBlocks(context_, &exit_bb_set);
+
+  std::unordered_set<ir::BasicBlock*> new_loop_exits;
+  bool made_change = false;
+  // For each block, we create a new one that gathers all branches from
+  // the loop and fall into the block.
+  for (uint32_t non_dedicate_id : exit_bb_set) {
+    ir::BasicBlock* non_dedicate = cfg.block(non_dedicate_id);
+    const std::vector<uint32_t>& bb_pred = cfg.preds(non_dedicate_id);
+    // Ignore the block if:
+    //   - all the predecessors are in the loop;
+    //   - and has an unconditional branch;
+    //   - and any other instructions are phi.
+    if (non_dedicate->tail()->opcode() == SpvOpBranch) {
+      if (std::all_of(bb_pred.begin(), bb_pred.end(), [this](uint32_t id) {
+            return loop_->IsInsideLoop(id);
+          })) {
+        ir::BasicBlock::iterator it = non_dedicate->tail();
+        if (it == non_dedicate->begin() || (--it)->opcode() == SpvOpPhi) {
+          new_loop_exits.insert(non_dedicate);
+          continue;
+        }
+      }
+    }
+
+    made_change = true;
+    ir::Function::iterator insert_pt = function->begin();
+    for (; insert_pt != function->end() && &*insert_pt != non_dedicate;
+         ++insert_pt) {
+    }
+    assert(insert_pt != function->end() && "Basic Block not found");
+
+    // Create the dedicate exit basic block.
+    ir::BasicBlock& exit = *insert_pt.InsertBefore(
+        std::unique_ptr<ir::BasicBlock>(new ir::BasicBlock(
+            std::unique_ptr<ir::Instruction>(new ir::Instruction(
+                context_, SpvOpLabel, 0, context_->TakeNextId(), {})))));
+    exit.SetParent(function);
+
+    // Redirect in loop predecessors to |exit| block.
+    for (uint32_t exit_pred_id : bb_pred) {
+      if (loop_->IsInsideLoop(exit_pred_id)) {
+        ir::BasicBlock* pred_block = cfg.block(exit_pred_id);
+        pred_block->ForEachSuccessorLabel([non_dedicate, &exit](uint32_t* id) {
+          if (*id == non_dedicate->id()) *id = exit.id();
+        });
+        // Update the CFG.
+        // |non_dedicate|'s predecessor list will be updated at the end of the
+        // loop.
+        cfg.RegisterBlock(pred_block);
+      }
+    }
+
+    // Register the label to the def/use manager, requires for the phi patching.
+    def_use_mgr->AnalyzeInstDefUse(exit.GetLabelInst());
+    context_->set_instr_block(exit.GetLabelInst(), &exit);
+
+    // Patch the phi nodes.
+    opt::InstructionBuilder<PreservedAnalyses> builder(context_,
+                                                       &*exit.begin());
+    non_dedicate->ForEachPhiInst([&builder, &exit, def_use_mgr,
+                                  this](ir::Instruction* phi) {
+      // New phi operands for this instruction.
+      std::vector<uint32_t> new_phi_op;
+      // Phi operands for the dedicated exit block.
+      std::vector<uint32_t> exit_phi_op;
+      for (uint32_t i = 0; i < phi->NumInOperands(); i += 2) {
+        uint32_t def_id = phi->GetSingleWordInOperand(i);
+        uint32_t incoming_id = phi->GetSingleWordInOperand(i + 1);
+        if (loop_->IsInsideLoop(incoming_id)) {
+          exit_phi_op.push_back(def_id);
+          exit_phi_op.push_back(incoming_id);
+        } else {
+          new_phi_op.push_back(def_id);
+          new_phi_op.push_back(incoming_id);
+        }
+      }
+
+      // Build the new phi instruction dedicated exit block.
+      ir::Instruction* exit_phi = builder.AddPhi(phi->type_id(), exit_phi_op);
+      // Build the new incoming branch.
+      new_phi_op.push_back(exit_phi->result_id());
+      new_phi_op.push_back(exit.id());
+      // Rewrite operands.
+      uint32_t idx = 0;
+      for (; idx < new_phi_op.size(); idx++)
+        phi->SetInOperand(idx, {new_phi_op[idx]});
+      // Remove extra operands, from last to first (more efficient).
+      for (uint32_t j = phi->NumInOperands() - 1; j >= idx; j--)
+        phi->RemoveInOperand(j);
+      // Update the def/use manager for this |phi|.
+      def_use_mgr->AnalyzeInstUse(phi);
+    });
+    // now jump from our dedicate basic block to the old exit.
+    builder.AddBranch(non_dedicate->id());
+    // Update the CFG.
+    cfg.RegisterBlock(&exit);
+    cfg.RemoveNonExistingEdges(non_dedicate->id());
+    new_loop_exits.insert(&exit);
+    // If non_dedicate is in a loop, add the new dedicated exit in that loop.
+    if (ir::Loop* parent_loop = loop_desc[non_dedicate])
+      parent_loop->AddBasicBlock(&exit);
+  }
+
+  if (new_loop_exits.size() == 1) {
+    loop_->SetMergeBlock(*new_loop_exits.begin());
+  }
+
+  if (made_change) {
+    context_->InvalidateAnalysesExceptFor(
+        PreservedAnalyses | ir::IRContext::kAnalysisCFG |
+        ir::IRContext::Analysis::kAnalysisLoopAnalysis);
+  }
+}
+
+void LoopUtils::MakeLoopClosedSSA() {
+  CreateLoopDedicateExits();
+
+  ir::Function* function = loop_->GetHeaderBlock()->GetParent();
+  ir::CFG& cfg = *context_->cfg();
+  opt::DominatorTree& dom_tree =
+      context_->GetDominatorAnalysis(function, cfg)->GetDomTree();
+
+  opt::analysis::DefUseManager* def_use_manager = context_->get_def_use_mgr();
+  std::unordered_set<ir::BasicBlock*> exit_bb;
+  for (uint32_t bb_id : loop_->GetBlocks()) {
+    ir::BasicBlock* bb = cfg.block(bb_id);
+    bb->ForEachSuccessorLabel([&exit_bb, &cfg, this](uint32_t succ) {
+      if (!loop_->IsInsideLoop(succ)) exit_bb.insert(cfg.block(succ));
+    });
+  }
+
+  for (uint32_t bb_id : loop_->GetBlocks()) {
+    ir::BasicBlock* bb = cfg.block(bb_id);
+    // If bb does not dominate an exit block, then it cannot have escaping defs.
+    if (!DominatesAnExit(bb, exit_bb, dom_tree)) continue;
+    for (ir::Instruction& inst : *bb) {
+      std::unordered_set<ir::BasicBlock*> processed_exit;
+      LCSSARewriter rewriter(context_, dom_tree, exit_bb, inst);
+      def_use_manager->ForEachUse(
+          &inst, [&rewriter, &exit_bb, &processed_exit, &inst, &dom_tree, &cfg,
+                  this](ir::Instruction* use, uint32_t operand_index) {
+            if (loop_->IsInsideLoop(use)) return;
+
+            ir::BasicBlock* use_parent = context_->get_instr_block(use);
+            assert(use_parent);
+            if (use->opcode() == SpvOpPhi) {
+              // If the use is a Phi instruction and the incoming block is
+              // coming from the loop, then that's consistent with LCSSA form.
+              if (exit_bb.count(use_parent)) {
+                rewriter.RegisterExitPhi(use_parent, use);
+                return;
+              } else {
+                // That's not an exit block, but the user is a phi instruction.
+                // Consider the incoming branch only: |use_parent| must be
+                // dominated by one of the exit block.
+                use_parent = context_->get_instr_block(
+                    use->GetSingleWordOperand(operand_index + 1));
+              }
+            }
+
+            for (ir::BasicBlock* e_bb : exit_bb) {
+              if (processed_exit.count(e_bb)) continue;
+              processed_exit.insert(e_bb);
+
+              // If the current exit basic block does not dominate |use| then
+              // |inst| does not escape through |e_bb|.
+              if (!dom_tree.Dominates(e_bb, use_parent)) continue;
+
+              opt::InstructionBuilder<> builder(context_, &*e_bb->begin());
+              const std::vector<uint32_t>& preds = cfg.preds(e_bb->id());
+              std::vector<uint32_t> incoming;
+              incoming.reserve(preds.size() * 2);
+              for (uint32_t pred_id : preds) {
+                incoming.push_back(inst.result_id());
+                incoming.push_back(pred_id);
+              }
+              rewriter.RegisterExitPhi(
+                  e_bb, builder.AddPhi(inst.type_id(), incoming));
+            }
+
+            // Rewrite the use. Note that this call does not invalidate the
+            // def/use manager. So this operation is safe.
+            rewriter.RewriteUse(use_parent, use, operand_index);
+          });
+      rewriter.UpdateManagers();
+    }
+  }
+
+  context_->InvalidateAnalysesExceptFor(
+      ir::IRContext::Analysis::kAnalysisDefUse |
+      ir::IRContext::Analysis::kAnalysisCFG |
+      ir::IRContext::Analysis::kAnalysisDominatorAnalysis |
+      ir::IRContext::Analysis::kAnalysisLoopAnalysis);
+}
+
+}  // namespace opt
+}  // namespace spvtools

--- a/source/opt/loop_utils.h
+++ b/source/opt/loop_utils.h
@@ -1,0 +1,75 @@
+// Copyright (c) 2018 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LIBSPIRV_OPT_LOOP_UTILS_H_
+#define LIBSPIRV_OPT_LOOP_UTILS_H_
+
+namespace spvtools {
+
+namespace ir {
+class Loop;
+class IRContext;
+}  // namespace ir
+
+namespace opt {
+
+// Set of basic loop transformation.
+class LoopUtils {
+ public:
+  LoopUtils(ir::IRContext* context, ir::Loop* loop)
+      : context_(context), loop_(loop) {}
+
+  // The make the current loop in the loop closed SSA form.
+  // In the loop closed SSA, all loop exiting values goes through a dedicate SSA
+  // instruction. For instance:
+  //
+  // for (...) {
+  //   A1 = ...
+  //   if (...)
+  //     A2 = ...
+  //   A = phi A1, A2
+  // }
+  // ... = op A ...
+  //
+  // Becomes
+  //
+  // for (...) {
+  //   A1 = ...
+  //   if (...)
+  //     A2 = ...
+  //   A = phi A1, A2
+  // }
+  // C = phi A
+  // ... = op C ...
+  //
+  // This makes some loop transformations (such as loop unswitch) simpler
+  // (removes the needs to take care of exiting variables).
+  void MakeLoopClosedSSA();
+
+  // Create dedicate exit basic block. This ensure all exit basic blocks as the
+  // loop as sole predecessors.
+  // By construction, structured control flow already has a dedicated exit
+  // block.
+  // Preserves: CFG, def/use and instruction to block mapping.
+  void CreateLoopDedicateExits();
+
+ private:
+  ir::IRContext* context_;
+  ir::Loop* loop_;
+};
+
+}  // namespace opt
+}  // namespace spvtools
+
+#endif  // LIBSPIRV_OPT_LOOP_UTILS_H_

--- a/test/opt/loop_optimizations/CMakeLists.txt
+++ b/test/opt/loop_optimizations/CMakeLists.txt
@@ -25,3 +25,8 @@ add_spvtools_unittest(TARGET loop_descriptor_nested
     LIBS SPIRV-Tools-opt
 )
 
+add_spvtools_unittest(TARGET lcssa_test
+    SRCS ../function_utils.h
+        lcssa.cpp
+    LIBS SPIRV-Tools-opt
+)

--- a/test/opt/loop_optimizations/lcssa.cpp
+++ b/test/opt/loop_optimizations/lcssa.cpp
@@ -1,0 +1,351 @@
+// Copyright (c) 2018 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#ifdef SPIRV_EFFCEE
+#include "effcee/effcee.h"
+#endif
+
+#include "../assembly_builder.h"
+#include "../function_utils.h"
+
+#include "opt/build_module.h"
+#include "opt/loop_descriptor.h"
+#include "opt/loop_utils.h"
+#include "opt/pass.h"
+
+namespace {
+
+using namespace spvtools;
+
+#ifdef SPIRV_EFFCEE
+
+bool Validate(const std::vector<uint32_t>& bin) {
+  spv_target_env target_env = SPV_ENV_UNIVERSAL_1_2;
+  spv_context spvContext = spvContextCreate(target_env);
+  spv_diagnostic diagnostic = nullptr;
+  spv_const_binary_t binary = {bin.data(), bin.size()};
+  spv_result_t error = spvValidate(spvContext, &binary, &diagnostic);
+  if (error != 0) spvDiagnosticPrint(diagnostic);
+  spvDiagnosticDestroy(diagnostic);
+  spvContextDestroy(spvContext);
+  return error == 0;
+}
+
+void Match(const std::string& original, ir::IRContext* context,
+           bool do_validation = true) {
+  std::vector<uint32_t> bin;
+  context->module()->ToBinary(&bin, true);
+  if (do_validation) {
+    EXPECT_TRUE(Validate(bin));
+  }
+  std::string assembly;
+  SpirvTools tools(SPV_ENV_UNIVERSAL_1_2);
+  EXPECT_TRUE(
+      tools.Disassemble(bin, &assembly, SPV_BINARY_TO_TEXT_OPTION_NO_HEADER))
+      << "Disassembling failed for shader:\n"
+      << assembly << std::endl;
+  auto match_result = effcee::Match(assembly, original);
+  EXPECT_EQ(effcee::Result::Status::Ok, match_result.status())
+      << match_result.message() << "\nChecking result:\n"
+      << assembly;
+}
+
+using LCSSATest = ::testing::Test;
+
+/*
+Generated from the following GLSL + --eliminate-local-multi-store
+
+#version 330 core
+layout(location = 0) out vec4 c;
+void main() {
+  int i = 0;
+  for (; i < 10; i++) {
+  }
+  if (i != 0) {
+    i = 1;
+  }
+}
+*/
+TEST_F(LCSSATest, SimpleLCSSA) {
+  const std::string text = R"(
+; CHECK: OpLoopMerge %32 %19 None
+; CHECK: %32 = OpLabel
+; CHECK-NEXT: %33 = OpPhi %7 %30 %20
+; CHECK-NEXT: OpBranch %18
+; CHECK-NEXT: %18 = OpLabel
+; CHECK-NEXT: %27 = OpINotEqual %11 %33 %9
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %2 "main" %3
+               OpExecutionMode %2 OriginUpperLeft
+               OpSource GLSL 330
+               OpName %2 "main"
+               OpName %3 "c"
+               OpDecorate %3 Location 0
+          %5 = OpTypeVoid
+          %6 = OpTypeFunction %5
+          %7 = OpTypeInt 32 1
+          %8 = OpTypePointer Function %7
+          %9 = OpConstant %7 0
+         %10 = OpConstant %7 10
+         %11 = OpTypeBool
+         %12 = OpConstant %7 1
+         %13 = OpTypeFloat 32
+         %14 = OpTypeVector %13 4
+         %15 = OpTypePointer Output %14
+          %3 = OpVariable %15 Output
+          %2 = OpFunction %5 None %6
+         %16 = OpLabel
+               OpBranch %17
+         %17 = OpLabel
+         %30 = OpPhi %7 %9 %16 %25 %19
+               OpLoopMerge %18 %19 None
+               OpBranch %20
+         %20 = OpLabel
+         %22 = OpSLessThan %11 %30 %10
+               OpBranchConditional %22 %23 %18
+         %23 = OpLabel
+               OpBranch %19
+         %19 = OpLabel
+         %25 = OpIAdd %7 %30 %12
+               OpBranch %17
+         %18 = OpLabel
+         %27 = OpINotEqual %11 %30 %9
+               OpSelectionMerge %28 None
+               OpBranchConditional %27 %29 %28
+         %29 = OpLabel
+               OpBranch %28
+         %28 = OpLabel
+         %31 = OpPhi %7 %30 %18 %12 %29
+               OpReturn
+               OpFunctionEnd
+  )";
+  std::unique_ptr<ir::IRContext> context =
+      BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, text,
+                  SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
+  ir::Module* module = context->module();
+  EXPECT_NE(nullptr, module) << "Assembling failed for shader:\n"
+                             << text << std::endl;
+  const ir::Function* f = spvtest::GetFunction(module, 2);
+  ir::LoopDescriptor ld{f};
+
+  ir::Loop* loop = ld[17];
+  EXPECT_FALSE(loop->IsLCSSA());
+  opt::LoopUtils Util(context.get(), loop);
+  Util.MakeLoopClosedSSA();
+  EXPECT_TRUE(loop->IsLCSSA());
+  Match(text, context.get());
+}
+
+/*
+Generated from the following GLSL + --eliminate-local-multi-store
+
+#version 330 core
+layout(location = 0) out vec4 c;
+void main() {
+  int i = 0;
+  int j = 0;
+  for (; i < 10; i++) {}
+  for (; j < 10; j++) {}
+  if (j != 0) {
+    i = 1;
+  }
+}
+*/
+TEST_F(LCSSATest, DualLoopLCSSA) {
+  const std::string text = R"(
+; CHECK: %20 = OpLabel
+; CHECK-NEXT: %36 = OpPhi %6 %17 %21
+; CHECK: %33 = OpLabel
+; CHECK-NEXT: %35 = OpPhi %6 %36 %28 %11 %34
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %2 "main" %3
+               OpExecutionMode %2 OriginUpperLeft
+               OpSource GLSL 330
+               OpName %2 "main"
+               OpName %3 "c"
+               OpDecorate %3 Location 0
+          %4 = OpTypeVoid
+          %5 = OpTypeFunction %4
+          %6 = OpTypeInt 32 1
+          %7 = OpTypePointer Function %6
+          %8 = OpConstant %6 0
+          %9 = OpConstant %6 10
+         %10 = OpTypeBool
+         %11 = OpConstant %6 1
+         %12 = OpTypeFloat 32
+         %13 = OpTypeVector %12 4
+         %14 = OpTypePointer Output %13
+          %3 = OpVariable %14 Output
+          %2 = OpFunction %4 None %5
+         %15 = OpLabel
+               OpBranch %16
+         %16 = OpLabel
+         %17 = OpPhi %6 %8 %15 %18 %19
+               OpLoopMerge %20 %19 None
+               OpBranch %21
+         %21 = OpLabel
+         %22 = OpSLessThan %10 %17 %9
+               OpBranchConditional %22 %23 %20
+         %23 = OpLabel
+               OpBranch %19
+         %19 = OpLabel
+         %18 = OpIAdd %6 %17 %11
+               OpBranch %16
+         %20 = OpLabel
+               OpBranch %24
+         %24 = OpLabel
+         %25 = OpPhi %6 %8 %20 %26 %27
+               OpLoopMerge %28 %27 None
+               OpBranch %29
+         %29 = OpLabel
+         %30 = OpSLessThan %10 %25 %9
+               OpBranchConditional %30 %31 %28
+         %31 = OpLabel
+               OpBranch %27
+         %27 = OpLabel
+         %26 = OpIAdd %6 %25 %11
+               OpBranch %24
+         %28 = OpLabel
+         %32 = OpINotEqual %10 %25 %8
+               OpSelectionMerge %33 None
+               OpBranchConditional %32 %34 %33
+         %34 = OpLabel
+               OpBranch %33
+         %33 = OpLabel
+         %35 = OpPhi %6 %17 %28 %11 %34
+               OpReturn
+               OpFunctionEnd
+  )";
+  std::unique_ptr<ir::IRContext> context =
+      BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, text,
+                  SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
+  ir::Module* module = context->module();
+  EXPECT_NE(nullptr, module) << "Assembling failed for shader:\n"
+                             << text << std::endl;
+  const ir::Function* f = spvtest::GetFunction(module, 2);
+  ir::LoopDescriptor ld{f};
+
+  ir::Loop* loop = ld[16];
+  EXPECT_FALSE(loop->IsLCSSA());
+  opt::LoopUtils Util(context.get(), loop);
+  Util.MakeLoopClosedSSA();
+  EXPECT_TRUE(loop->IsLCSSA());
+  Match(text, context.get());
+}
+
+/*
+Generated from the following GLSL + --eliminate-local-multi-store
+
+#version 330 core
+layout(location = 0) out vec4 c;
+void main() {
+  int i = 0;
+  if (i != 0) {
+    for (; i < 10; i++) {}
+  }
+  if (i != 0) {
+    i = 1;
+  }
+}
+*/
+TEST_F(LCSSATest, PhiUserLCSSA) {
+  const std::string text = R"(
+; CHECK: %23 = OpLabel
+; CHECK-NEXT: %32 = OpPhi %6 %20 %24
+; CHECK: %17 = OpLabel
+; CHECK-NEXT: %27 = OpPhi %6 %8 %15 %32 %23
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %2 "main" %3
+               OpExecutionMode %2 OriginUpperLeft
+               OpSource GLSL 330
+               OpName %2 "main"
+               OpName %3 "c"
+               OpDecorate %3 Location 0
+          %4 = OpTypeVoid
+          %5 = OpTypeFunction %4
+          %6 = OpTypeInt 32 1
+          %7 = OpTypePointer Function %6
+          %8 = OpConstant %6 0
+          %9 = OpTypeBool
+         %10 = OpConstant %6 10
+         %11 = OpConstant %6 1
+         %12 = OpTypeFloat 32
+         %13 = OpTypeVector %12 4
+         %14 = OpTypePointer Output %13
+          %3 = OpVariable %14 Output
+          %2 = OpFunction %4 None %5
+         %15 = OpLabel
+         %16 = OpINotEqual %9 %8 %8
+               OpSelectionMerge %17 None
+               OpBranchConditional %16 %18 %17
+         %18 = OpLabel
+               OpBranch %19
+         %19 = OpLabel
+         %20 = OpPhi %6 %8 %18 %21 %22
+               OpLoopMerge %23 %22 None
+               OpBranch %24
+         %24 = OpLabel
+         %25 = OpSLessThan %9 %20 %10
+               OpBranchConditional %25 %26 %23
+         %26 = OpLabel
+               OpBranch %22
+         %22 = OpLabel
+         %21 = OpIAdd %6 %20 %11
+               OpBranch %19
+         %23 = OpLabel
+               OpBranch %17
+         %17 = OpLabel
+         %27 = OpPhi %6 %8 %15 %20 %23
+         %28 = OpINotEqual %9 %27 %8
+               OpSelectionMerge %29 None
+               OpBranchConditional %28 %30 %29
+         %30 = OpLabel
+               OpBranch %29
+         %29 = OpLabel
+         %31 = OpPhi %6 %27 %17 %11 %30
+               OpReturn
+               OpFunctionEnd
+  )";
+  std::unique_ptr<ir::IRContext> context =
+      BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, text,
+                  SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
+  ir::Module* module = context->module();
+  EXPECT_NE(nullptr, module) << "Assembling failed for shader:\n"
+                             << text << std::endl;
+  const ir::Function* f = spvtest::GetFunction(module, 2);
+  ir::LoopDescriptor ld{f};
+
+  ir::Loop* loop = ld[19];
+  EXPECT_FALSE(loop->IsLCSSA());
+  opt::LoopUtils Util(context.get(), loop);
+  Util.MakeLoopClosedSSA();
+  EXPECT_TRUE(loop->IsLCSSA());
+  Match(text, context.get());
+}
+
+#endif  // SPIRV_EFFCEE
+
+}  // namespace

--- a/test/opt/loop_optimizations/loop_descriptions.cpp
+++ b/test/opt/loop_optimizations/loop_descriptions.cpp
@@ -200,6 +200,7 @@ TEST_F(PassClassTest, LoopWithNoPreHeader) {
 
   ir::Loop* loop = ld[27];
   EXPECT_EQ(loop->GetPreHeaderBlock(), nullptr);
+  EXPECT_NE(loop->GetOrCreatePreHeaderBlock(context.get()), nullptr);
 }
 
 }  // namespace


### PR DESCRIPTION
This patch introduce:
 - LoopUtil class to handle some loop related transformations, for now 2 transformations are implemented:
   - Dedicate exit blocks: this ensure that all exit basic block
       (out-of-loop basic blocks that have a predecessor in the loop)
       have all their predecessors in the loop;
   - Loop Closed SSA (LCSSA): this ensure that all definitions in a loop are used inside the loop
       or in a phi instruction in an exit basic block.
       This simplify the logic for transformations such as loop unroll or unswitch.
 - Loop::IsLCSSA to test if the loop is in a LCSSA form
 - New methods to allow in-place update of the CFG analysis.